### PR TITLE
Fix issue with MemberOffer SQL

### DIFF
--- a/app.js
+++ b/app.js
@@ -365,7 +365,42 @@ async function addQueryActivity(payload, seed) {
 					if ( payloadAttributes.online_promotion_type == 'unique') {
 
 						// handle unique query + instore code
-						memberOfferQuery = "SELECT A.SCHEME_ID, A.LOYALTY_CARD_NUMBER, A.OFFER_ID, vp.CouponCode AS VOUCHER_ON_LINE_CODE, A.VOUCHER_IN_STORE_CODE AS VOUCHER_IN_STORE_CODE, A.[START_DATE_TIME], A.[END_DATE_TIME], A.NO_REDEMPTIONS_ALLOWED, A.[VISIBLE_FROM_DATE_TIME], A.STATUS FROM ( SELECT 'Matalan' AS SCHEME_ID, " + appCardNumber + " AS LOYALTY_CARD_NUMBER, MPT.offer_id AS OFFER_ID, MPT.offer_instore_code_1 AS VOUCHER_IN_STORE_CODE, CONCAT(MPT.offer_start_date, ' ', MPT.offer_start_time) AS [START_DATE_TIME], CONCAT(MPT.offer_end_date, ' ', MPT.offer_end_time) AS [END_DATE_TIME], MPT.offer_redemptions  AS NO_REDEMPTIONS_ALLOWED, CONCAT(MPT.offer_start_date, ' ', MPT.offer_start_time) AS [VISIBLE_FROM_DATE_TIME], MPT.offer_status AS STATUS, RN = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) FROM [" + payloadAttributes.update_contact + "] as UpdateContactDE LEFT JOIN [" + marketingCloud.mobilePushMainTable + "] AS MPT ON MPT.push_key = '" + payloadAttributes.key + "' INNER JOIN [" + sourceDataModel + "] AS PCD ON PCD.PARTY_ID = UpdateContactDE.PARTY_ID ) A LEFT JOIN [" + payloadAttributes.unique_code_1 + "] AS VP ON A.RN = VP.RowNumber";
+						memberOfferQuery =
+						`SELECT A.SCHEME_ID,
+						A.LOYALTY_CARD_NUMBER,
+						A.OFFER_ID,
+						vp.CouponCode AS VOUCHER_ON_LINE_CODE,
+						A.VOUCHER_IN_STORE_CODE AS VOUCHER_IN_STORE_CODE,
+						A.[START_DATE_TIME],
+						A.[END_DATE_TIME],
+						A.NO_REDEMPTIONS_ALLOWED,
+						A.[VISIBLE_FROM_DATE_TIME],
+						A.STATUS 
+						FROM (
+							SELECT 'Matalan' AS SCHEME_ID,
+							${appCardNumber} AS LOYALTY_CARD_NUMBER,
+							MPT.offer_id AS OFFER_ID,
+							MPT.offer_instore_code_1 AS VOUCHER_IN_STORE_CODE,
+							CONCAT(MPT.offer_start_date, ' ', MPT.offer_start_time) AS [START_DATE_TIME],
+							CONCAT(MPT.offer_end_date, ' ', MPT.offer_end_time) AS [END_DATE_TIME],
+							MPT.offer_redemptions  AS NO_REDEMPTIONS_ALLOWED,
+							CONCAT(MPT.offer_start_date, ' ', MPT.offer_start_time) AS [VISIBLE_FROM_DATE_TIME],
+							MPT.offer_status AS STATUS,
+							RN = ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+							FROM [${payloadAttributes.update_contact}] as UpdateContactDE
+							LEFT JOIN [${marketingCloud.mobilePushMainTable}] AS MPT
+							ON MPT.push_key = '${payloadAttributes.key}'
+							INNER JOIN [${sourceDataModel}] AS PCD
+							ON PCD.PARTY_ID = UpdateContactDE.PARTY_ID
+						) A 
+						LEFT JOIN (
+							SELECT  CouponCode
+							,       RN = ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+							FROM    [${payloadAttributes.unique_code_1}]
+							WHERE   IsClaimed = 0
+						) VP
+						ON A.RN = VP.RN`
+
 						console.dir(memberOfferQuery);
 					
 					} else {


### PR DESCRIPTION
Hi Paul,

As per my email:

I’ve made an update to the member offer SQL that gets around the issue, and removes the need for the rownumber column on the voucher DEs.  I’ve also come up with something that may allow us to avoid having to rewrite SQL to and from one-line.

If you can check over the change, and deploy the update that would be fab.

David